### PR TITLE
Add pH range selection for recipes

### DIFF
--- a/app/src/main/java/com/example/kombuchaapp/ViewRecipeActivity.java
+++ b/app/src/main/java/com/example/kombuchaapp/ViewRecipeActivity.java
@@ -59,7 +59,8 @@ public class ViewRecipeActivity extends AppCompatActivity {
     private TextView tvRecipeName, tvStatus, tvTeaLeaf, tvWater, tvSugar, tvScoby,
             tvKombuchaStarter, tvFlavor, tvCreatedDate, tvBrewingStartDate,
             tvCompletionDate, tvNotes, tvTempAlert;
-    private TextView tvLiveTemperature, tvLivePh, tvFermentationStage;
+    private TextView tvLiveTemperature, tvLivePh, tvFermentationStage,
+            minPhTextView, maxPhTextView, pHTypeTextView;
     private View liveTempContainer, livePhContainer;
     private Button btnEdit, btnStartBrewing, btnMarkCompleted, btnPauseBrewing,
             btnResumeBrewing, btnBackToDraft, btnRebrew;
@@ -173,6 +174,35 @@ public class ViewRecipeActivity extends AppCompatActivity {
         tvFermentationStage = findViewById(R.id.tv_fermentation_stage);
         liveTempContainer = findViewById(R.id.live_temp_container);
         livePhContainer = findViewById(R.id.live_ph_container);
+
+        minPhTextView = findViewById(R.id.minPhTextView);
+        maxPhTextView = findViewById(R.id.maxPhTextView);
+        pHTypeTextView = findViewById(R.id.phTypeTextView);
+    }
+
+    private void displayPhRange(Recipe recipe) {
+        double minPh = recipe.getMinPh();
+        double maxPh = recipe.getMaxPh();
+
+        // Display pH values
+        minPhTextView.setText(String.format("%.1f", minPh));
+        maxPhTextView.setText(String.format("%.1f", maxPh));
+
+        // Determine and display pH type
+        String phType = getPhType(minPh, maxPh);
+        pHTypeTextView.setText("(" + phType + ")");
+    }
+
+    private String getPhType(double minPh, double maxPh) {
+        if (Math.abs(minPh - 4.0) < 0.01 && Math.abs(maxPh - 4.5) < 0.01) {
+            return "Sweet";
+        } else if (Math.abs(minPh - 3.5) < 0.01 && Math.abs(maxPh - 4.5) < 0.01) {
+            return "Tangy";
+        } else if (Math.abs(minPh - 0) < 0.01 && Math.abs(maxPh - 3.5) < 0.01) {
+            return "Vinegary";
+        } else {
+            return "Custom";
+        }
     }
 
     /**
@@ -290,6 +320,7 @@ public class ViewRecipeActivity extends AppCompatActivity {
                     showLoading(false);
                     currentRecipe = recipe;
                     displayRecipe(recipe);
+                    displayPhRange(recipe);
                 });
             }
 
@@ -913,23 +944,37 @@ public class ViewRecipeActivity extends AppCompatActivity {
                     // Update live pH display
                     updateLivePh(ph);
 
+                    // Check if pH is within the harvest range AND we haven't notified yet
                     if (currentRecipe != null
                             && "brewing".equalsIgnoreCase(currentRecipe.getStatus())
                             && !hasHarvestNotified
-                            && !Float.isNaN(ph)
-                            && Math.abs(ph - 3.0f) <= 0.05f) {
+                            && !Float.isNaN(ph)) {
 
-                        hasHarvestNotified = true;
+                        double minPh = currentRecipe.getMinPh();
+                        double maxPh = currentRecipe.getMaxPh();
 
-                        PhAlert.Result r = PhAlert.evaluate(ph);
+                        // Check if pH is within the user's desired harvest range
+                        if (ph >= minPh && ph <= maxPh) {
+                            hasHarvestNotified = true;
 
-                        NotificationHelper.notifyReadyToHarvest(
-                                getApplicationContext(),
-                                recipeId,
-                                r.title,
-                                r.message,
-                                ph
-                        );
+                            // Create custom message based on pH type
+                            String phType = getPhType(minPh, maxPh);
+                            String title = "Ready to Harvest!";
+                            String message = String.format(
+                                    "Your kombucha has reached the %s range (%.1f-%.1f pH). Time to taste and bottle!",
+                                    phType, minPh, maxPh
+                            );
+
+                            Log.d(TAG, "pH notification triggered: " + message);
+
+                            NotificationHelper.notifyReadyToHarvest(
+                                    getApplicationContext(),
+                                    recipeId,
+                                    title,
+                                    message,
+                                    ph
+                            );
+                        }
                     }
                 });
     }

--- a/app/src/main/java/com/example/kombuchaapp/models/Recipe.java
+++ b/app/src/main/java/com/example/kombuchaapp/models/Recipe.java
@@ -24,6 +24,8 @@ public class Recipe {
     private Timestamp completionDate;
     private String status;
     private String notes;
+    private double minPh;
+    private double maxPh;
     
     public Recipe() {
         this.status = "draft";
@@ -43,7 +45,23 @@ public class Recipe {
         this.status = "draft";
         this.createdDate = Timestamp.now();
     }
-    
+
+    public Recipe(String userId, String recipeName, String teaLeaf, String water,
+                  String sugar, String scoby, String kombuchaStarter, String flavor, double minPh, double maxPh) {
+        this.userId = userId;
+        this.recipeName = recipeName;
+        this.teaLeaf = teaLeaf;
+        this.water = water;
+        this.sugar = sugar;
+        this.scoby = scoby;
+        this.kombuchaStarter = kombuchaStarter;
+        this.flavor = flavor;
+        this.minPh = minPh;
+        this.maxPh = maxPh;
+        this.status = "draft";
+        this.createdDate = Timestamp.now();
+    }
+
     public String getRecipeId() { return recipeId; }
     public String getUserId() { return userId; }
     public String getRecipeName() { return recipeName; }
@@ -73,7 +91,19 @@ public class Recipe {
     public void setCompletionDate(Timestamp completionDate) { this.completionDate = completionDate; }
     public void setStatus(String status) { this.status = status; }
     public void setNotes(String notes) { this.notes = notes; }
-    
+    public double getMinPh() {
+        return minPh;
+    }
+    public void setMinPh(double minPh) {
+        this.minPh = minPh;
+    }
+    public double getMaxPh() {
+        return maxPh;
+    }
+    public void setMaxPh(double maxPh) {
+        this.maxPh = maxPh;
+    }
+
     @Override
     public String toString() {
         return "Recipe{" +

--- a/app/src/main/java/com/example/kombuchaapp/repositories/RecipeRepository.java
+++ b/app/src/main/java/com/example/kombuchaapp/repositories/RecipeRepository.java
@@ -71,6 +71,8 @@ public class RecipeRepository {
         recipeData.put("status", recipe.getStatus());
         recipeData.put("createdDate", recipe.getCreatedDate());
         recipeData.put("notes", recipe.getNotes());
+        recipeData.put("minPh", recipe.getMinPh());
+        recipeData.put("maxPh", recipe.getMaxPh());
 
         // Add to Firestore (auto-generates document ID)
         recipesRef.add(recipeData)
@@ -158,6 +160,8 @@ public class RecipeRepository {
         updates.put("flavor", recipe.getFlavor());
         updates.put("status", recipe.getStatus());
         updates.put("notes", recipe.getNotes());
+        updates.put("minPh", recipe.getMinPh());
+        updates.put("maxPh", recipe.getMaxPh());
 
         recipesRef.document(recipeId)
                 .update(updates)
@@ -364,6 +368,8 @@ public class RecipeRepository {
     }
 
     // Parse Firestore document into Recipe object
+// Replace the parseRecipe method in RecipeRepository.java with this:
+
     private Recipe parseRecipe(DocumentSnapshot doc) {
         Recipe recipe = new Recipe();
         recipe.setRecipeId(doc.getId());
@@ -380,6 +386,35 @@ public class RecipeRepository {
         recipe.setCreatedDate(doc.getTimestamp("createdDate"));
         recipe.setBrewingStartDate(doc.getTimestamp("brewingStartDate"));
         recipe.setCompletionDate(doc.getTimestamp("completionDate"));
+
+        try {
+            Object minPhObj = doc.get("minPh");
+            if (minPhObj != null) {
+                if (minPhObj instanceof Double) {
+                    recipe.setMinPh((Double) minPhObj);
+                } else if (minPhObj instanceof Long) {
+                    recipe.setMinPh(((Long) minPhObj).doubleValue());
+                }
+            } else {
+                recipe.setMinPh(0.0); // Default value
+            }
+
+            Object maxPhObj = doc.get("maxPh");
+            if (maxPhObj != null) {
+                if (maxPhObj instanceof Double) {
+                    recipe.setMaxPh((Double) maxPhObj);
+                } else if (maxPhObj instanceof Long) {
+                    recipe.setMaxPh(((Long) maxPhObj).doubleValue());
+                }
+            } else {
+                recipe.setMaxPh(0.0); // Default value
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Error parsing pH values: " + e.getMessage());
+            recipe.setMinPh(0.0);
+            recipe.setMaxPh(0.0);
+        }
+
         return recipe;
     }
 

--- a/app/src/main/res/layout/activity_create_anew_recipe.xml
+++ b/app/src/main/res/layout/activity_create_anew_recipe.xml
@@ -208,6 +208,105 @@
                 android:background="@android:drawable/edit_text" />
 
             <TextView
+                android:id="@+id/harvestTextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="25dp"
+                android:layout_marginTop="15dp"
+                android:text="Harvest pH range"
+                android:textColor="#8B4513"
+                android:textStyle="bold" />
+
+            <androidx.cardview.widget.CardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="4dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <RadioGroup
+                        android:id="@+id/phRadioGroup"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content">
+
+                        <RadioButton
+                            android:id="@+id/sweetRadioButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Sweet (pH 4.0–4.5)"
+                            android:textColor="#8B4513" />
+
+                        <RadioButton
+                            android:id="@+id/tangyRadioButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Tangy (pH 3.5-4.5)"
+                            android:textColor="#8B4513" />
+
+                        <RadioButton
+                            android:id="@+id/vinegaryRadioButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Vinegary (pH &lt; 3.5)"
+                            android:textColor="#8B4513" />
+
+                        <RadioButton
+                            android:id="@+id/customPhRadioButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Custom pH harvest range"
+                            android:textColor="#8B4513" />
+                    </RadioGroup>
+
+                    <LinearLayout
+                        android:id="@+id/customPhLayout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="10dp"
+                        android:orientation="horizontal"
+                        android:visibility="gone">
+
+                        <EditText
+                            android:id="@+id/minPhEditText"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:layout_marginEnd="8dp"
+                            android:hint="Min pH"
+                            android:textColorHint="#CD853F"
+                            android:textColor="#8B4513"
+                            android:inputType="numberDecimal"
+                            android:minHeight="48dp"
+                            android:padding="12dp"
+                            android:background="@android:drawable/edit_text" />
+
+                        <EditText
+                            android:id="@+id/maxPhEditText"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:layout_marginStart="8dp"
+                            android:hint="Max pH"
+                            android:textColorHint="#CD853F"
+                            android:textColor="#8B4513"
+                            android:inputType="numberDecimal"
+                            android:minHeight="48dp"
+                            android:padding="12dp"
+                            android:background="@android:drawable/edit_text" />
+                    </LinearLayout>
+                </LinearLayout>
+            </androidx.cardview.widget.CardView>
+
+            <TextView
                 android:id="@+id/textView11"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_edit_recipe.xml
+++ b/app/src/main/res/layout/activity_edit_recipe.xml
@@ -256,7 +256,7 @@
                             android:id="@+id/vinegaryRadioButton"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Vinegary (pH > 3.5)"
+                            android:text="Vinegary (pH &lt; 3.5)"
                             android:textColor="#8B4513" />
 
                         <RadioButton

--- a/app/src/main/res/layout/activity_edit_recipe.xml
+++ b/app/src/main/res/layout/activity_edit_recipe.xml
@@ -208,6 +208,105 @@
                 android:background="@android:drawable/edit_text" />
 
             <TextView
+                android:id="@+id/harvestTextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="25dp"
+                android:layout_marginTop="15dp"
+                android:text="Harvest pH range"
+                android:textColor="#8B4513"
+                android:textStyle="bold" />
+
+            <androidx.cardview.widget.CardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="4dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <RadioGroup
+                        android:id="@+id/phRadioGroup"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content">
+
+                        <RadioButton
+                            android:id="@+id/sweetRadioButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Sweet (pH 4.0–4.5)"
+                            android:textColor="#8B4513" />
+
+                        <RadioButton
+                            android:id="@+id/tangyRadioButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Tangy (pH 3.5-4.5)"
+                            android:textColor="#8B4513" />
+
+                        <RadioButton
+                            android:id="@+id/vinegaryRadioButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Vinegary (pH > 3.5)"
+                            android:textColor="#8B4513" />
+
+                        <RadioButton
+                            android:id="@+id/customPhRadioButton"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Custom pH harvest range"
+                            android:textColor="#8B4513" />
+                    </RadioGroup>
+
+                    <LinearLayout
+                        android:id="@+id/customPhLayout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="10dp"
+                        android:orientation="horizontal"
+                        android:visibility="gone">
+
+                        <EditText
+                            android:id="@+id/minPhEditText"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:layout_marginEnd="8dp"
+                            android:hint="Min pH"
+                            android:textColorHint="#CD853F"
+                            android:textColor="#8B4513"
+                            android:inputType="numberDecimal"
+                            android:minHeight="48dp"
+                            android:padding="12dp"
+                            android:background="@android:drawable/edit_text" />
+
+                        <EditText
+                            android:id="@+id/maxPhEditText"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:layout_marginStart="8dp"
+                            android:hint="Max pH"
+                            android:textColorHint="#CD853F"
+                            android:textColor="#8B4513"
+                            android:inputType="numberDecimal"
+                            android:minHeight="48dp"
+                            android:padding="12dp"
+                            android:background="@android:drawable/edit_text" />
+                    </LinearLayout>
+                </LinearLayout>
+            </androidx.cardview.widget.CardView>
+
+            <TextView
                 android:id="@+id/textView11"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_view_recipe.xml
+++ b/app/src/main/res/layout/activity_view_recipe.xml
@@ -458,6 +458,83 @@
 
             </androidx.cardview.widget.CardView>
 
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Harvest pH Range"
+                android:textSize="14sp"
+                android:textStyle="bold"
+                android:textColor="#D2691E"
+                android:layout_marginBottom="8dp"
+                android:letterSpacing="0.1" />
+
+            <androidx.cardview.widget.CardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="4dp"
+                android:layout_marginBottom="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Min pH: "
+                            android:textColor="#8B4513"
+                            android:textStyle="bold"
+                            android:textSize="14sp" />
+
+                        <TextView
+                            android:id="@+id/minPhTextView"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="4.0"
+                            android:textColor="#8B4513"
+                            android:textSize="14sp"
+                            android:layout_marginEnd="16dp" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Max pH: "
+                            android:textColor="#8B4513"
+                            android:textStyle="bold"
+                            android:textSize="14sp" />
+
+                        <TextView
+                            android:id="@+id/maxPhTextView"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="4.5"
+                            android:textColor="#8B4513"
+                            android:textSize="14sp" />
+                    </LinearLayout>
+
+                    <TextView
+                        android:id="@+id/phTypeTextView"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="(Sweet)"
+                        android:textColor="#CD853F"
+                        android:textSize="12sp"
+                        android:textStyle="italic"
+                        android:layout_marginTop="4dp" />
+
+                </LinearLayout>
+
+            </androidx.cardview.widget.CardView>
+
             <!-- Dates Section -->
             <TextView
                 android:layout_width="match_parent"


### PR DESCRIPTION
This commit introduces a feature allowing users to select a target pH range for harvesting their kombucha.

Key changes:
- Added `minPh` and `maxPh` fields to the `Recipe` model.
- Updated `CreateANewRecipe` and `EditRecipeActivity` to include a UI for selecting a pH range (Sweet, Tangy, Vinegary, or Custom).
- The `ViewRecipeActivity` now displays the selected pH range.
- The `RecipeRepository` is updated to handle storing and retrieving these new pH values from Firestore.
- Harvest notifications are now triggered based on the user-defined pH range for the recipe.